### PR TITLE
Exclude certain files during site generation.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ baseurl: "/dragoman"
 paginate_path: "blog/page:num/"
 permalink: blog/:title/
 
+exclude: ["node_modules", "config.rb", "Gemfile", "Gemfile.lock"]
 markdown: kramdown
 highlighter: rouge
 gems: [jekyll-paginate]


### PR DESCRIPTION
Jekyll's `_config.yml` [supports](https://jekyllrb.com/docs/configuration/) `exlude` config where you can provide list of files and folders that you want to prevent from copying into generated `_site` directory while running `jekyll build`.
